### PR TITLE
Added test_who_wins_betwen_two_equal_method_names in about_proxy_object_...

### DIFF
--- a/src/about_proxy_object_project.rb
+++ b/src/about_proxy_object_project.rb
@@ -30,6 +30,10 @@ class Proxy
     @object.send(sym, *args, &block)
   end
 
+  def brand?
+    "Proxy"
+  end
+
   def called?(method)
     @messages.include?(method)
   end
@@ -101,6 +105,12 @@ class AboutProxyObjectProject < Neo::Koan
     assert_equal 0, tv.number_of_times_called(:on?)
   end
 
+  def test_who_wins_betwen_two_equal_method_names
+    tv = Proxy.new(Television.new)
+
+    assert_equal __("Proxy"), tv.brand?
+  end
+
   def test_proxy_can_record_more_than_just_tv_objects
     proxy = Proxy.new("Code Mash 2009")
 
@@ -120,6 +130,10 @@ end
 # Example class using in the proxy testing above.
 class Television
   attr_accessor :channel
+
+  def brand?
+    "Acme"
+  end
 
   def power
     if @power == :on


### PR DESCRIPTION
Added test_who_wins_betwen_two_equal_method_names in about_proxy_object_project.rb

This test method shows that if there are two methods with the same name wins the proxy method.
